### PR TITLE
Increase package version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-action",
   "description": "GitHub Actions TypeScript template",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "author": "",
   "type": "module",
   "private": true,


### PR DESCRIPTION
Version bump for the v0.5.0 release: adds export mode (#42) — new `export` / `export-encoding` inputs and `tx` output, backwards compatible, so a minor bump.

After merge: tag `v0.5.0` + GitHub release, then move the SHA pin in solana-foundation/github-workflows#5 to the tag.