### PR TITLE
Point export example at v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ multisig member imports the output into the
 import, one approval.
 
 ```yaml
-- uses: solana-foundation/squads-program-action@v0.4.4
+- uses: solana-foundation/squads-program-action@v0.5.0
   id: export-squads-tx
   with:
     rpc: ${{ secrets.RPC_URL }}


### PR DESCRIPTION
README export-mode example referenced v0.4.4, which predates the `export` input. Bump to v0.5.0.